### PR TITLE
Update components.keyword.channel to allow private messages to bot as well.

### DIFF
--- a/pyaib/components.py
+++ b/pyaib/components.py
@@ -147,7 +147,9 @@ class triggers_on(object):
                         return
                 elif dec.args and msg.channel not in dec.args:
                     return
-                return dec.call(irc_c, msg, trigger, args, kargs)
+            elif not dec.kwargs.get('private'):
+                return
+            return dec.call(irc_c, msg, trigger, args, kargs)
 
     class private(EasyDecorator):
         """Only pass if triggers is from message not in a channel"""


### PR DESCRIPTION
Given that @keyword.channel and @keyword.private seem to be mutually exclusive (you wrap twice, and one will always fail) This short patch adds a keyword argument to @keyword.channel called private which if True will allow the command to be requested via PRIVMSG as well as in the channels listed.
