### PR TITLE
Fix "dictionary changed size during iteration" bug with python 3.5

### DIFF
--- a/pyaib/util/data.py
+++ b/pyaib/util/data.py
@@ -63,7 +63,7 @@ class Object(dict):
         self.__dict__['__PROTECTED__'] = set()
         #Make sure all children are Object not dict
         #Also handle 'a.b.c' style keys
-        for k in self.keys():
+        for k in list(self.keys()):
             self[k] = self.pop(k)
 
     def __wrap(self, value):


### PR DESCRIPTION
A bug I found while trying to get my bot running on python 3.5.