### PR TITLE
Passing data between greenlets

### DIFF
--- a/example/plugins/signals.py
+++ b/example/plugins/signals.py
@@ -33,7 +33,8 @@ class Names:
         channel = response[0]
         names = response[1]
         assert channel == message.channel
-        message.reply("List of channel members: %s" % len(names))
+        message.reply("List of channel members: %s" % ", ".join(names))
+        # Warning, this will annoy everyone in the channel.
 
     @observe('IRC_MSG_353') # 353 indicates a NAMES response.
     def recieve_names(self, irc_c, message):

--- a/example/plugins/signals.py
+++ b/example/plugins/signals.py
@@ -1,0 +1,50 @@
+"""Example file for signals."""
+
+from pyiab.plugins import plugin_class
+from pyaib.components import observe, awaits_signal
+from pyaib.signals import emit_signal, await_signal
+import re
+
+@plugin_class('names')
+class Names:
+    """This plugin provides a command ('names') that outputs a list of all
+    nicks currently in the channel."""
+    def __init__(self, irc_c, config):
+        print("Names plugin loaded")
+
+    @keyword('names')
+    def get_list_of_names(self, irc_c, message, trigger, args, kwargs):
+        # Sends a NAMES request to the server, to get a list of nicks for the
+        # current channel.
+        # Issue the NAMES request:
+        irc_c.RAW("NAMES %s" % message.channel)
+        # The request has been sent.
+        # pyaib is asynchronous, so another function will recieve the response
+        # from this request.
+        # That function must send the data here via a signal.
+        try:
+            # Wait for the signal (up to 10 seconds).
+            response = await_signal(irc_c, 'NAMES_RESPONSE', timeout=10.0)
+            # await_signal returns whatever data we choose to send, or True.
+        except TimeoutError:
+            message.reply("The request timed out.")
+            return
+        # The NAMES response is now saved.
+        channel = response[0]
+        names = response[1]
+        assert channel == message.channel
+        message.reply("List of channel members: %s" % ", ".join(names))
+
+    @observe('IRC_MSG_353') # 353 indicates a NAMES response.
+    def recieve_names(self, irc_c, message):
+        # The response is in message.args as a single string.
+        # "MYNICK = #channel :nick1 nick2 nick3"
+        # Split that up into individual names:
+        response = re.split(r"\s:?", message.args.strip())[2:]
+        channel = response.pop(0)
+        names = response[:]
+        # Great, we've caught the NAMES response.
+        # Now send it back to the function that wanted it.
+        emit_signal(irc_c, 'NAMES_RESPONSE', data=(channel, names))
+        # The signal name can be anything, so long as emit_signal and
+        # await_signal use the same one.

--- a/example/plugins/signals.py
+++ b/example/plugins/signals.py
@@ -33,7 +33,7 @@ class Names:
         channel = response[0]
         names = response[1]
         assert channel == message.channel
-        message.reply("List of channel members: %s" % ", ".join(names))
+        message.reply("List of channel members: %s" % len(names))
 
     @observe('IRC_MSG_353') # 353 indicates a NAMES response.
     def recieve_names(self, irc_c, message):
@@ -41,8 +41,8 @@ class Names:
         # "MYNICK = #channel :nick1 nick2 nick3"
         # Split that up into individual names:
         response = re.split(r"\s:?", message.args.strip())[2:]
-        channel = response.pop(0)
-        names = response[:]
+        channel = response[0]
+        names = response[1:]
         # Great, we've caught the NAMES response.
         # Now send it back to the function that wanted it.
         emit_signal(irc_c, 'NAMES_RESPONSE', data=(channel, names))

--- a/pyaib/components.py
+++ b/pyaib/components.py
@@ -346,7 +346,7 @@ class ComponentManager(object):
                     self._add_parsers(method, name, chain)
             elif kind == 'signals':
                 for signal in args:
-                    context.signals(word).observe(method)
+                    context.signals(signal).observe(method)
 
     def _add_parsers(self, method, name, chain):
         """ Handle Message parser adding and chaining """

--- a/pyaib/components.py
+++ b/pyaib/components.py
@@ -108,6 +108,14 @@ observe = watches
 handle = watches
 handles = watches
 
+def awaits_signal(*signals):
+    """Define a series of signals to later be subscribed to"""
+    def wrapper(func):
+        splugs = _get_plugs(func, 'signals')
+        splugs.extend([signal for signal in signals if signal not in splugs])
+        return func
+    return wrapper
+
 
 class _Ignore(EasyDecorator):
     """Only pass if triggers is from user not ignored"""

--- a/pyaib/components.py
+++ b/pyaib/components.py
@@ -108,6 +108,7 @@ observe = watches
 handle = watches
 handles = watches
 
+
 def awaits_signal(*signals):
     """Define a series of signals to later be subscribed to"""
     def wrapper(func):
@@ -343,6 +344,9 @@ class ComponentManager(object):
             elif kind == 'parsers':
                 for name, chain in args:
                     self._add_parsers(method, name, chain)
+            elif kind == 'signals':
+                for signal in args:
+                    context.signals(word).observe(method)
 
     def _add_parsers(self, method, name, chain):
         """ Handle Message parser adding and chaining """

--- a/pyaib/ircbot.py
+++ b/pyaib/ircbot.py
@@ -35,6 +35,7 @@ import gevent
 from .config import Config
 from .events import Events
 from .timers import Timers
+from .signals import Signals
 from .components import ComponentManager
 from . import irc
 
@@ -54,6 +55,7 @@ class IrcBot(object):
         #Install most basic fundamental functionality
         install('events', self._loadComponent(Events, False))
         install('timers', self._loadComponent(Timers, False))
+        install('signals', self._loadComponent(Signals, False))
 
         #Load the ComponentManager and load components
         autoload = ['triggers', 'channels', 'plugins']  # Force these to load

--- a/pyaib/signals.py
+++ b/pyaib/signals.py
@@ -1,0 +1,20 @@
+def emit_signal(signal_name):
+    """Emits the signal of the given name."""
+
+def await_signal(signal_name):
+    """Blocks until the signal of the given name is recieved."""
+
+def awaits_signal(signal_name):
+    """Decorator; call this function when the signal is recieved."""
+    def wrapper(func):
+        pass
+    return wrapper
+
+class Signal:
+    def __init__(self):
+        pass
+
+class Signals:
+    # Stores all the different signals.
+    # There are no pre-defined signals - they will be created by the end user.
+    pass

--- a/pyaib/signals.py
+++ b/pyaib/signals.py
@@ -20,18 +20,6 @@ def await_signal(irc_c, name, timeout=None):
         raise TimeoutError("Waiting for signal %s timed out" % name)
     return recieved
 
-def awaits_signal(name):
-    # XXX moved to components (where watches is)
-    """Decorator; call this function when the signal is recieved."""
-    # XXX this shouldn't have irc_c? How do other decorators work
-    # create signal if it doesn't already exist
-    signal = irc_c.signals(name)
-    # add this function to the list of observers
-    def wrapper(func):
-        signal.observe(func)
-        return func
-    return wrapper
-
 def _unfire_signal(name, irc_c):
     """Resets emitted signals for later reuse."""
     irc_c.signals[name].unfire()

--- a/pyaib/signals.py
+++ b/pyaib/signals.py
@@ -2,11 +2,13 @@
 
 import collections
 import gevent.event
+from copy import copy
 
 from . import irc
 
 def emit_signal(irc_c, name, *, data=None):
     """Emits the signal of the given name."""
+    print('Emitting {} with {}'.format(name, data))
     if not isinstance(irc_c, irc.Context):
         raise TypeError("First argument must be IRC context")
     # create signal if it doesn't already exist
@@ -18,22 +20,20 @@ def await_signal(irc_c, name, *, timeout=None):
     if not isinstance(irc_c, irc.Context):
         raise TypeError("First argument must be IRC context")
     # create signal if it doesn't already exist
-    event = irc_c.signals(name)._event
-    recieved = event.wait(timeout)
+    signal = irc_c.signals(name)
+    recieved = signal._event.wait(timeout)
     if recieved is False:
         raise TimeoutError("Waiting for signal %s timed out" % name)
-    return recieved
-
-def _unfire_signal(name, irc_c):
-    """Resets emitted signals for later reuse."""
-    # TODO make arguments match what emission actually does
-    irc_c.signals[name].unfire()
+    data = copy(signal._data)
+    print('Found {} with {}'.format(name, data))
+    return data
 
 class Signal:
-    def __init__(self):
+    def __init__(self, name):
         self.__observers = [] # list of stuff waiting on this event
-        self.__observers.append(_unfire_signal)
         self._event = gevent.event.Event()
+        self._data = None
+        self.name = name
 
     def observe(self, observer):
         if isinstance(observer, collections.Callable):
@@ -46,22 +46,33 @@ class Signal:
         self.__observers.remove(observer)
         return self
 
-    def fire(self, *args, **kwargs):
-        # args kept in 1 argument to be passed to greenlet easily
-        irc_c = args[0]
+    def fire(self, irc_c, data):
         assert isinstance(irc_c, irc.Context)
+        # Queue the function that unfires this event
         # activate the event for waiting existing greenlets
+        self._data = data
         self._event.set()
         # manually initiate decorated observers
         for observer in self.__observers:
             if isinstance(observer, collections.Callable):
-                irc_c.bot_greenlets.spawn(observer, *args, **kwargs)
+                irc_c.bot_greenlets.spawn(observer, irc_c, copy(data))
             else:
                 raise TypeError("%s not callable" % repr(observer))
+        # finally, initiate the unfiring event
+        irc_c.bot_greenlets.spawn(self.wait_then_unfire, irc_c)
 
     def unfire(self):
         # reset the gevent event
         self._event.clear()
+        self._data = None
+
+    def wait_then_unfire(self, irc_c):
+        print("UNF Waiting to unfire {}".format(self.name))
+        # Waits for the signal, then unfires it.
+        # Guaranteed to be the last existing waiter executed.
+        await_signal(irc_c, self.name)
+        print("UNF Unfiring {}".format(self.name))
+        self.unfire()
 
     def getObserverCount(self):
         return len(self.__observers)
@@ -94,7 +105,7 @@ class Signals:
     def getOrMake(self, name):
         if not self.isSignal(name):
             #Make Event if it does not exist
-            self.__signals[name.lower()] = Signal()
+            self.__signals[name.lower()] = Signal(name)
         return self.get(name)
 
     #Return the null signal on non existent signal

--- a/pyaib/signals.py
+++ b/pyaib/signals.py
@@ -20,7 +20,7 @@ def await_signal(irc_c, name, *, timeout=None):
     # create signal if it doesn't already exist
     event = irc_c.signals(name)._event
     recieved = event.wait(timeout)
-    if not recieved:
+    if recieved is False:
         raise TimeoutError("Waiting for signal %s timed out" % name)
     return recieved
 
@@ -49,10 +49,10 @@ class Signal:
     def fire(self, *args, **kwargs):
         # args kept in 1 argument to be passed to greenlet easily
         irc_c = args[0]
-        data = args[1]
-        # initiate a decorated waiter.
-        # existing waiting greenlets are not affected by this
         assert isinstance(irc_c, irc.Context)
+        # activate the event for waiting existing greenlets
+        self._event.set()
+        # manually initiate decorated observers
         for observer in self.__observers:
             if isinstance(observer, collections.Callable):
                 irc_c.bot_greenlets.spawn(observer, *args, **kwargs)

--- a/pyaib/signals.py
+++ b/pyaib/signals.py
@@ -1,20 +1,117 @@
-def emit_signal(signal_name):
+#!/usr/bin/env python
+
+import collections
+import gevent.event
+
+from . import irc
+
+def emit_signal(irc_c, name):
     """Emits the signal of the given name."""
+    # TODO create signal if it doesn't already exist
 
-def await_signal(signal_name):
+def await_signal(irc_c, name, timeout=None):
     """Blocks until the signal of the given name is recieved."""
+    # TODO create signal if it doesn't already exist
+    # add myself to the list of observers
+    event = irc_c.signals(name)._event
+    recieved = event.wait(timeout)
+    if not recieved:
+        raise TimeoutError("Waiting for signal %s timed out" % name)
+    return recieved
+    # remove myself from the list of observers
 
-def awaits_signal(signal_name):
+def awaits_signal(irc_c, name):
     """Decorator; call this function when the signal is recieved."""
+    # XXX this shouldn't have irc_c? How do other decorators work
+    # TODO create signal if it doesn't already exist
+    # add this function to the list of observers
     def wrapper(func):
         pass
     return wrapper
 
+def _unfire_signal(name, irc_c):
+    """Resets emitted signals for later reuse."""
+    irc_c.signals[name].unfire()
+
 class Signal:
     def __init__(self):
-        pass
+        self.__observers = [] # list of stuff waiting on this event
+        self._event = gevent.event.Event()
+
+    def observe(self, observer):
+        # XXX this is ok for decorators but not normal waiters
+        if isinstance(observer, collections.Callable):
+            self.__observers.append(observer)
+        else:
+            # XXX should throw?
+            raise TypeError("%s not callable" % repr(observer))
+        return self
+
+    def unobserve(self, observer):
+        self.__observers.remove(observer)
+        return self
+
+    def fire(self, irc_c, *args, **keywargs):
+        assert isinstance(irc_c, irc.Context)
+        # initiate or resume each observer
+        for observer in self.__observers:
+            if isinstance(observer, collections.Callable):
+                irc_c.bot_greenlets.spawn(observer, *args, **keywargs)
+            elif False:
+                # TODO resume existing wating greenlets
+                pass
+            else:
+                raise TypeError("%s not callable" % repr(observer))
+
+    def unfire(self):
+        # reset the gevent event
+        self._event.clear()
+
+    def getObserverCount(self):
+        return len(self.__observers)
+
+    def observers(self):
+        return self.__observers
+
+    def __bool__(self):
+        return self.getObserverCount() > 0
+
+    __nonzero__ = __bool__  # 2.x compat
+    __iadd__ = observe
+    __isub__ = unobserve
+    __call__ = fire
+    __len__ = getObserverCount
 
 class Signals:
     # Stores all the different signals.
     # There are no pre-defined signals - they will be created by the end user.
+    def __init__(self, irc_c):
+        self.__signals = {}
+        self.__nullSignal = NullSignal() # is this necessary?
+
+    def list(self):
+        return self.__signals.keys()
+
+    def isSignal(self, name):
+        return name.lower() in self.__signals
+
+    def getOrMake(self, name):
+        if not self.isSignal(name):
+            #Make Event if it does not exist
+            self.__signals[name.lower()] = Signal()
+        return self.get(name)
+
+    #Return the null signal on non existent signal
+    def get(self, name):
+        signal = self.__signals.get(name.lower())
+        if signal is None:  # Only on undefined events
+            return self.__nullSignal
+        return signal
+
+    __contains__ = isSignal
+    __call__ = getOrMake
+    __getitem__ = get
+
+class NullSignal:
+    # not sure this is even needed
     pass

--- a/pyaib/signals.py
+++ b/pyaib/signals.py
@@ -8,7 +8,6 @@ from . import irc
 
 def emit_signal(irc_c, name, *, data=None):
     """Emits the signal of the given name."""
-    print('Emitting {} with {}'.format(name, data))
     if not isinstance(irc_c, irc.Context):
         raise TypeError("First argument must be IRC context")
     # create signal if it doesn't already exist
@@ -25,7 +24,6 @@ def await_signal(irc_c, name, *, timeout=None):
     if recieved is False:
         raise TimeoutError("Waiting for signal %s timed out" % name)
     data = copy(signal._data)
-    print('Found {} with {}'.format(name, data))
     return data
 
 class Signal:

--- a/pyaib/signals.py
+++ b/pyaib/signals.py
@@ -5,14 +5,18 @@ import gevent.event
 
 from . import irc
 
-def emit_signal(irc_c, name, data=None):
+def emit_signal(irc_c, name, *, data=None):
     """Emits the signal of the given name."""
+    if not isinstance(irc_c, irc.Context):
+        raise TypeError("First argument must be IRC context")
     # create signal if it doesn't already exist
     signal = irc_c.signals(name)
     signal.fire(irc_c, data)
 
-def await_signal(irc_c, name, timeout=None):
+def await_signal(irc_c, name, *, timeout=None):
     """Blocks until the signal of the given name is recieved."""
+    if not isinstance(irc_c, irc.Context):
+        raise TypeError("First argument must be IRC context")
     # create signal if it doesn't already exist
     event = irc_c.signals(name)._event
     recieved = event.wait(timeout)
@@ -22,6 +26,7 @@ def await_signal(irc_c, name, timeout=None):
 
 def _unfire_signal(name, irc_c):
     """Resets emitted signals for later reuse."""
+    # TODO make arguments match what emission actually does
     irc_c.signals[name].unfire()
 
 class Signal:

--- a/pyaib/signals.py
+++ b/pyaib/signals.py
@@ -57,19 +57,17 @@ class Signal:
             else:
                 raise TypeError("%s not callable" % repr(observer))
         # finally, initiate the unfiring event
-        irc_c.bot_greenlets.spawn(self.wait_then_unfire, irc_c)
+        irc_c.bot_greenlets.spawn(self.wait_then_unfire)
 
     def unfire(self):
         # reset the gevent event
         self._event.clear()
         self._data = None
 
-    def wait_then_unfire(self, irc_c):
-        print("UNF Waiting to unfire {}".format(self.name))
+    def wait_then_unfire(self):
         # Waits for the signal, then unfires it.
         # Guaranteed to be the last existing waiter executed.
-        await_signal(irc_c, self.name)
-        print("UNF Unfiring {}".format(self.name))
+        self._event.wait()
         self.unfire()
 
     def getObserverCount(self):


### PR DESCRIPTION
pyaib's eponymous asynchronous nature makes it difficult - if not outright impossible - to pass data between greenlets, or pause a greenlet to wait for some event.

Not good enough for me - I had a situation where I needed a keyword command to request a fresh NAMES response from the server and compare that to the cached NAMES response in my database. How could I possibly do that? In a function decorated with `@keyword`, I can't stop it in the middle and wait for `@observe('IRC_MSG_353')`. They would both have to be handled by different functions - different, completely separate, asynchronous functions.

This PR introduces a new concept: Signals, which are pretty much a fork of Events. Signals are messages broadcasted from one greenlet to all others. They have a name/ID and can carry data with them.

This PR introduces a new decorator and two new functions:
* `pyaib.signals.emit_signal`: a non-blocking function that emits a signal. Takes arguments `irc_context` and the name/ID of the signal to be broadcasted. Has an optional `data` kwarg that specifies an object to be sent along with the signal, which all recipient greenlets will recieve.
* `pyaib.components.awaits_signal`: a decorator for plugin functions. The function is called when the signal is received. (Added for consistency with Events; not sure I see a use case)
* `pyaib.signals.await_signal`: a function that blocks until the signal is recieved. Takes arguments `irc_context` and the name/ID of the signal to wait for. Has an optional `timeout` kwarg which is a float specifying the number of seconds to wait for before raising `TimeoutError`. If not specified, it will wait forever. Returns whatever `data` was transmitted along with the signal, defaulting to None.

Example usage (a truncated [examples/plugins/signals.py](https://github.com/facebook/pyaib/pull/24/files#diff-39fd9221b0c698a98f263a3ce1157d03)):
```python
from pyiab.plugins import plugin_class
from pyaib.components import observe, awaits_signal
from pyaib.signals import emit_signal, await_signal
import re

@plugin_class('names')
class Names:
    @keyword('names')
    def get_list_of_names(self, irc_c, message, trigger, args, kwargs):
        irc_c.RAW("NAMES %s" % message.channel)
        try:
            response = await_signal(irc_c, 'NAMES_RESPONSE', timeout=10.0)
        except TimeoutError:
            message.reply("The request timed out.")
            return
        channel = response[0]
        names = response[1]
        assert channel == message.channel
        message.reply("List of channel members: %s" % ", ".join(names))

    @observe('IRC_MSG_353') # 353 indicates a NAMES response
    def recieve_names(self, irc_c, message):
        response = re.split(r"\s:?", message.args.strip())[2:]
        channel = response[0]
        names = response[1:]
        emit_signal(irc_c, 'NAMES_RESPONSE', data=(channel, names))
```

The development process can be found here: https://github.com/rossjrw/pyaib/pull/1